### PR TITLE
Store notificaitons in /var/log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ usbguard-notifier.service
 # doc, man
 man/usbguard-notifier.1
 man/usbguard-notifier-cli.1
+
+# others
+src/build-config.h
+usbguard-notifier.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,8 @@ usbguard_notifier_SOURCES = \
 	src/NotifyWrapper.hpp \
 	src/Log.hpp \
 	src/Main.cpp \
+	src/ConfigParser.cpp \
+	src/ConfigParser.hpp \
 	src/Notifier.cpp \
 	src/Log.cpp \
 	icons/usbguard-icon.svg
@@ -22,8 +24,12 @@ usbguard_notifier_CXXFLAGS = \
 	@notify_CFLAGS@ \
 	@usbguard_CFLAGS@
 
-# manual pages
+BUILT_SOURCES = \
+	src/build-config.h
 
+#
+# manual pages
+#
 SUFFIXES = .adoc
 
 .adoc: 
@@ -33,18 +39,23 @@ man1_MANS = \
 	$(top_builddir)/man/usbguard-notifier.1 \
 	$(top_builddir)/man/usbguard-notifier-cli.1
 
+#
 # usbguard icon
-
+#
 .svg.o:
 	$(LD) -r -b binary -o $@ $<
 
+#
 # unit file
-
-install-data-hook: install-systemd-service
-uninstall-hook: uninstall-systemd-service
+#
+install-data-hook: install-systemd-service install-usbguard-notifier-conf
+uninstall-hook: uninstall-systemd-service uninstall-usbguard-notifier-conf
 
 CLEANFILES += $(top_builddir)/usbguard-notifier.service
 
+#
+# Notifier service
+#
 usbguard-notifier.service: $(top_srcdir)/usbguard-notifier.service.in
 	$(SED) -e "s|%bindir%|${bindir}|" $^ > $@ || rm -f $@
 
@@ -55,3 +66,32 @@ install-systemd-service: $(top_builddir)/usbguard-notifier.service
 
 uninstall-systemd-service:
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/usbguard-notifier.service
+
+CLEANFILES += $(top_builddir)/usbguard-notifier.service
+
+#
+# Saved notificaitons file path
+#
+usbguard-notifier.conf: $(top_builddir)/usbguard-notifier.conf.in
+	$(SED) \
+		-e "s|%notification_path%|@prefix@|g" \
+		$^ > $@ || rm -f $@
+
+install-usbguard-notifier-conf: $(top_builddir)/usbguard-notifier.conf
+	$(MKDIR_P) @config_PATH@/usbguard-notifier
+	$(INSTALL) -m 666 \
+		$(top_builddir)/usbguard-notifier.conf \
+		@config_PATH@/usbguard-notifier/usbguard-notifier.conf
+
+uninstall-usbguard-notifier-conf:
+	rm -f @config_PATH@/usbguard-notifier/usbguard-notifier.conf
+
+CLEANFILES += $(top_builddir)/usbguard-notifier.conf
+
+#
+# Common defines
+#
+$(top_builddir)/src/build-config.h: $(top_builddir)/src/build-config.h.in
+	$(SED) -e "s|%CONF_FILE%|@config_PATH@/usbguard-notifier/usbguard-notifier.conf|g" $^ > $@ || rm -f $@
+
+CLEANFILES += $(top_builddir)/src/build-config.h

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,13 @@ AC_TYPE_UINT8_T
 
 AC_CHECK_HEADERS([getopt.h unistd.h] ,[], [AC_MSG_ERROR([Required header file(s) not found])], [])
 
+AC_ARG_WITH([config-file],
+            [AS_HELP_STRING([--with-config-file],
+            [Support user defined config path])],
+            [with_config_file=$withval],
+            [with_config_file=$prefix/.config]
+)
+
 # protobuf
 PKG_CHECK_MODULES(
     [protobuf],
@@ -100,18 +107,23 @@ CXXFLAGS+=" -Wall"
 CXXFLAGS+=" -Wextra"
 
 AC_SUBST(CPPFLAGS, $CXXFLAGS)
+AC_SUBST(config_PATH, $with_config_file)
 
 AC_CONFIG_FILES(Makefile)
 
 AC_OUTPUT
 
 echo ""
-echo "========== MACROS =============="
-echo "    systemd: $systemd_unit_dir"
+echo "============== MACROS ================="
+echo "         systemd: $systemd_unit_dir    "
 echo ""
-echo "======== LINKER OPTIONS ========"
-echo "   protobuf: $protobuf_summary"
-echo "      libqb: $libqb_summary"
-echo "  libnotify: $libnotify_summary"
-echo "libusbguard: $libusbguard_summary"
+echo "========== LINKER OPTIONS ============="
+echo "        protobuf:$protobuf_summary"
+echo "           libqb:$libqb_summary"
+echo "       libnotify: $libnotify_summary"
+echo "     libusbguard: $libusbguard_summary"
+echo ""
+echo "=========== ARGUMENTS ================="
+echo "          prefix: $prefix"
+echo "with_config_file: $with_config_file"
 echo ""

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -1,0 +1,41 @@
+#include "ConfigParser.hpp"
+
+#include <iostream>
+
+namespace usbguardNotifier
+{
+    static const std::vector<std::string> g_nconfig_names = {
+        "NotificationPath"
+    };
+
+    std::map<std::string, std::string> Notifier::parseConfigFile(std::string file_path)
+    {
+        std::map<std::string, std::string> config;
+
+        std::ifstream f;
+        f.open(file_path, std::ifstream::in);
+        if (!f.good())
+        {
+            std::cerr << "Could not open " << file_path << std::endl;
+            // TODO
+        }
+
+        std::string line;
+        while (std::getline(f, line))
+        {
+            for(auto key: g_nconfig_names) {
+
+                std::string value;
+                if (line.substr(0, key.size()) == key)
+                {
+                    value = line.substr(key.size()+1);
+                    config[key] = value;
+                    // std::cout << key << "=" << value << "\n";
+                }
+            }
+        }
+
+        return config;
+    }
+
+} /* namespace usbguardNotifier */

--- a/src/ConfigParser.hpp
+++ b/src/ConfigParser.hpp
@@ -1,0 +1,1 @@
+#include "Notifier.hpp"

--- a/src/Log.hpp
+++ b/src/Log.hpp
@@ -16,6 +16,7 @@ public:
     LoggerStream createLogMessage(const std::string& file, const std::string& function, int line);
     void setDebugMode(bool debug);
     bool isEnabled() const;
+private:
     bool _debug;
 };
 

--- a/src/Notifier.hpp
+++ b/src/Notifier.hpp
@@ -4,6 +4,7 @@
 #include "NotifyWrapper.hpp"
 
 #include <usbguard/IPCClient.hpp>
+#include <map>
 
 namespace usbguardNotifier
 {
@@ -11,8 +12,7 @@ namespace usbguardNotifier
 class Notifier : public usbguard::IPCClient
 {
 public:
-    explicit Notifier(const std::string& appName)
-        : _lib(appName) {}
+    Notifier(const std::string& app_name);
 
     void DevicePolicyChanged(
         uint32_t id,
@@ -33,7 +33,22 @@ public:
         const std::string& value_new);
 
 private:
+    std::map<std::string, std::string> parseConfigFile(std::string file_path);
+
+    struct Data {
+        const uint32_t id;
+        const std::string event_type;
+        const std::string device_name;
+        const std::string target_old;
+        const std::string target_new;
+        const uint32_t rule_id;
+        const std::string rule;
+    };
+
+    void storeNotification(const Data& data);
+
     notify::Notify _lib;
+    std::map<std::string, std::string> _config;
 };
 
 } // namespace usbguardNotifier

--- a/src/build-config.h.in
+++ b/src/build-config.h.in
@@ -1,0 +1,4 @@
+/*
+ * Notification config file
+ */
+#define CONF_FILE "%CONF_FILE%"

--- a/usbguard-notifier.conf.in
+++ b/usbguard-notifier.conf.in
@@ -1,0 +1,1 @@
+NotificationPath=%notification_path%/notifications.log


### PR DESCRIPTION
Each registered notification is now appended to a simple plain text file. These will be used to manipulate with certain notifications using the usbguard-notification-CLI.  