### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:29
 
 script:
-    - docker run  -v /home/travis/build/Cropi/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make ./autogen.sh && ./configure --prefix /home/$(id -un) && make"
+    - docker run  -v /home/travis/build/Cropi/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make && ./autogen.sh && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:29
 
 script:
-    - docker run  -v /home/travis/build/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y libgcrypt-devel"
+    - docker run  -v /home/travis/build/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:29
 
 script:
-    - docker run  -v /home/travis/build/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel"
+    - docker run  -v /home/travis/build/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make ./autogen.sh && ./configure --prefix /home/$(id -un) && make"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:29
 
 script:
-    - docker run  -v /home/travis/build/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make ./autogen.sh && ./configure --prefix /home/$(id -un) && make"
+    - docker run  -v /home/travis/build/Cropi/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make ./autogen.sh && ./configure --prefix /home/$(id -un) && make"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:29
 
 script:
-    - docker run  -v /home/travis/build/usbguard-notifier/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y systemd-devel autoconf automake libtool make ansible usbguard usbguard-dev libnotify libnotify-devel && ./autogen.sh && ./configure --prefix /home/$(id -un) && make"
+    - docker run  -v /home/travis/build/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y libgcrypt-devel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:29
 
 script:
-    - docker run  -v /home/travis/build/Cropi/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make && ./autogen.sh && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"
+    - docker run  -v /home/travis/build/Cropi/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make  gcc-c++ asciidoc && ./autogen.sh && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,12 @@
-language: cpp
-compiler:
-- clang
-- gcc
-os: linux
 sudo: required
-dist: trusty
-matrix:
-    include:
-        - os: linux
-        compiler: gcc
-        addons:
-            apt:
-                sources: ['ubuntu-toolchain-r-test']
-                packages: ['g++-6', 'gcc-6']
-        env: CXX=g++-6 CC=gcc-6
-        - os: linux
-        compiler: clang
-        addons:
-            apt:
-                sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
-                packages: ['clang-3.8']
-        env: CXX=clang++-3.8 C=clang-3.8
+
+language: cpp
+
+services:
+    - docker
 
 before_install:
-- sudo add-apt-repository -y ppa:chris-lea/libsodium
-- sudo apt-get -qq update
-- sudo apt-get install -y ansible
-- sudo apt-get install -y libudev-dev libsodium-dev libqb-dev libcap-ng-dev libseccomp-dev
-- sudo apt-get install -y libglib2.0-dev libdbus-glib-1-dev libxml2-utils libpolkit-gobject-1-dev xsltproc
-- sudo apt-get install -y lcov
-- sudo apt-get install -y aspell aspell-en
-- sudo apt-get install -y libprotobuf-dev protobuf-compiler
-- sudo apt-get install -y libldap-dev
-- sudo apt-get install -y valgrind
-- sudo apt-get install -y umockdev libumockdev-dev
-- sudo gem install coveralls-lcov
-- sudo apt-get install -y usbguard usbguard-dev
-- sudo apt-get install -y libnotify libnotify-dev
+    - docker pull fedora:29
 
-install:
-- ./autogen.sh
-- CXX=${COMPILER_CXX:=$CXX} CC=${COMPILER_C:=$CC} ./configure
-- make
-- sudo make install
-
-
+script:
+    - docker run  -v /home/travis/build/usbguard-notifier/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; ls -la; pwd; cd usbguard-notifier; dnf install --nogpgcheck -y systemd-devel autoconf automake libtool make ansible usbguard usbguard-dev libnotify libnotify-devel && ./autogen.sh && ./configure --prefix /home/$(id -un) && make"


### PR DESCRIPTION
The problem was that the default build environment for travis is Ubuntu, which does not provide **usbguard-devel** package required to compile the source code.

This patch utilizes the features of travis by using docker.