### PR TITLE
Enhnacements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
     - docker pull fedora:30
 
 script:
-    - docker run  -v $TRAVIS_BUILD_DIR/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; cd usbguard-notifier; dnf install --nogpgcheck -y protobuf protobuf-devel libqb libqb-devel librsvg2 librsvg2-devel libnotify libnotify-devel usbguard usbguard-devel autoconf automake libtool make  gcc-c++ asciidoc git && ./autogen.sh && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"
+    - docker run  -v $TRAVIS_BUILD_DIR/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; cd usbguard-notifier; dnf install --nogpgcheck -y librsvg2-devel libnotify-devel usbguard-devel autoconf automake libtool make  gcc-c++ asciidoc git && ./autogen.sh && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # USBGuard Notifier
 
 [![Build Status](https://travis-ci.org/Cropi/usbguard-notifier.svg?branch=master)](https://travis-ci.org/Cropi/usbguard-notifier)
+[![License](https://img.shields.io/github/license/Cropi/usbguard-notifier.svg)](LICENSE)
 
 ### About
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,14 +42,6 @@ AC_ARG_ENABLE([permanent-notifications],
     [notification_path="/tmp/`id -un`"]
 )
 
-# protobuf
-PKG_CHECK_MODULES(
-    [protobuf],
-    [protobuf >= 2.5.0],
-    [protobuf_summary="$protobuf_CFLAGS $protobuf_LIBS"],
-    [AC_MSG_ERROR([Required protobuf development files not found!])]
-)
-
 # libqb
 PKG_CHECK_MODULES(
     [qb],
@@ -81,12 +73,6 @@ PKG_CHECK_MODULES(
     [libusbguard_summary="$usbguard_CFLAGS $usbguard_LIBS"],
     [AC_MSG_FAILURE([libusbguard development files not found])]
 )
-
-# protoc
-AC_CHECK_PROGS(PROTOC, [protoc])
-if test -z "$PROTOC"; then
-  AC_MSG_ERROR(["Required protoc compiler not found!"])
-fi
 
 # asciidoc
 AC_CHECK_PROGS(A2X, [a2x])


### PR DESCRIPTION
Added:
* license badge
* removed unnecessary dependencies

Not added yet, but may be added if there will be an official release (not pre-release).
```md
[![Release](https://img.shields.io/github/release/Cropi/usbguard-notifier.svg)](https://github.com/Cropi/usbguard-notifier/releases/latest)
[![Commits](https://img.shields.io/github/commits-since/Cropi/usbguard-notifier/latest.svg)](https://github.com/Cropi/usbguard-notifier/commits/master)
```
For now, the proposed badges will display `no releases or repo not found`.