### PR TITLE
Add asciidoc to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ In order to compile the sources from a tarball/zip you will need the following d
 * [usbguard](https://github.com/USBGuard/usbguard/)
 * [libnotify](https://github.com/GNOME/libnotify)
 * [librsvg](https://github.com/GNOME/librsvg)
+* [asciidoc](https://github.com/asciidoc/asciidoc)
 
 
 ### Instalation


### PR DESCRIPTION
When building from source and asciidoc is not present, an error will
occur.