### PR TITLE
long line changed to folded block scalar in YAML (.travis.yml)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,9 @@ before_install:
     - docker pull fedora:30
 
 script:
-    - docker run  -v $TRAVIS_BUILD_DIR/:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; cd usbguard-notifier; dnf install --nogpgcheck -y librsvg2-devel libnotify-devel usbguard-devel autoconf automake libtool make  gcc-c++ asciidoc git && ./autogen.sh && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"
+    - >
+      docker run -v $TRAVIS_BUILD_DIR/:/root/build/ fedora:rawhide
+      /bin/sh -c "cd /root/build; cd usbguard-notifier; dnf install
+      --nogpgcheck -y librsvg2-devel libnotify-devel usbguard-devel
+      autoconf automake libtool make gcc-c++ asciidoc git && ./autogen.sh
+      && ./configure --prefix /home/$(id -un) --with-bundled-catch && make"


### PR DESCRIPTION
Line folding allows long lines to be broken for readability, while retaining
the semantics of the original long line. Each line break '\n' is replaced by
a space ' ' while using a '>' (greater than) symbol in YAML notation.