### PR TITLE
removed deprecated 'sudo' from '.travis.yml'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: cpp
 
 services:


### PR DESCRIPTION
Deprecation is reported by the latest Travis linter [2, 3].
[x] [warn] on root: deprecated key: sudo (The key `sudo` has no effect anymore.)

![Screenshot from 2020-02-18 09-12-28](https://user-images.githubusercontent.com/22373707/74716476-ef00c600-522e-11ea-84c5-fa32afd8bee1.png)

Related sources to the deprecated 'sudo' feature.
[1] https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
[2] https://support.travis-ci.com/hc/en-us/articles/115002904174-Validating-travis-yml-files
[3] https://github.com/travis-ci/travis.rb