### PR TITLE
Merge notifications when inserting devices.

### DIFF
--- a/src/Notifier.cpp
+++ b/src/Notifier.cpp
@@ -25,6 +25,7 @@
 #include <stdexcept>
 #include <string>
 #include <unistd.h>
+#include <chrono>
 
 #include <usbguard/DeviceManager.hpp>
 #include <usbguard/Rule.hpp>
@@ -41,6 +42,14 @@ Notifier::Notifier(const std::string& app_name) :
     _ser.setFileName(path);
 }
 
+Notifier::~Notifier()
+{
+    for (auto t : countdownThreads) {
+        t->join();
+        delete t;
+    }
+}
+
 void Notifier::DevicePolicyChanged(
     uint32_t id,
     usbguard::Rule::Target target_old,
@@ -53,6 +62,20 @@ void Notifier::DevicePolicyChanged(
 
     const std::string target_old_str = Rule::targetToString(target_old);
     const std::string target_new_str = Rule::targetToString(target_new);
+
+    DevicePresenceInfo info = getDevicePresenceObject(id);
+    if (info.isInitialized) {
+        if (info.target == target_old ||
+            device_rule.substr(target_new_str.size()) == info.device_rule.substr(target_old_str.size())) {
+            info.target = target_new;
+            sendDevicePresenceNotification(info);
+            return;
+        } else {
+            NOTIFIER_LOG() << "DevicePolicyChanged and DevicePresenceChanged " <<
+                "with same id do not share the same rule.";
+        }
+    }
+
     Rule rule = Rule::fromString(device_rule);
 
     std::ostringstream body;
@@ -70,7 +93,7 @@ void Notifier::DevicePolicyChanged(
 }
 
 void Notifier::DevicePresenceChanged(
-    uint32_t /*id*/,
+    uint32_t id,
     usbguard::DeviceManager::EventType event,
     usbguard::Rule::Target target,
     const std::string& device_rule)
@@ -78,9 +101,41 @@ void Notifier::DevicePresenceChanged(
     using namespace usbguard;
     NOTIFIER_LOG() << "Device presence changed signal";
 
-    const std::string event_str = DeviceManager::eventTypeToString(event);
-    const std::string target_str = Rule::targetToString(target);
-    Rule rule = Rule::fromString(device_rule);
+    deviceNotifications.emplace(std::make_pair(id, DevicePresenceInfo(event, target, device_rule)));
+    std::thread* t = new std::thread( [this, id] { sendDevicePresenceCountdownCallback(id); } );
+    countdownThreads.push_back(t);
+}
+
+Notifier::DevicePresenceInfo Notifier::getDevicePresenceObject(uint32_t id)
+{
+    DevicePresenceInfo info;
+    mtx.lock();
+    auto it = deviceNotifications.find(id);
+    if (it != deviceNotifications.end()) {
+        info = it->second;
+        deviceNotifications.erase(it);
+    }
+    mtx.unlock();
+    return info;
+}
+
+void Notifier::sendDevicePresenceCountdownCallback(uint32_t id)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(millisecondsDevicePolicyWait));
+
+    DevicePresenceInfo info = getDevicePresenceObject(id);
+    if (info.isInitialized) {
+        sendDevicePresenceNotification(info);
+    }
+}
+
+void Notifier::sendDevicePresenceNotification(DevicePresenceInfo& info)
+{
+    using namespace usbguard;
+
+    const std::string event_str = DeviceManager::eventTypeToString(info.event);
+    const std::string target_str = Rule::targetToString(info.target);
+    Rule rule = Rule::fromString(info.device_rule);
 
     std::ostringstream body;
     body << event_str << ' ' << rule.getName() << ": " << target_str;

--- a/src/Notifier.hpp
+++ b/src/Notifier.hpp
@@ -78,10 +78,10 @@ private:
 
     notify::Notify _lib;
     Serializer _ser;
-    std::map<uint32_t, DevicePresenceInfo> deviceNotifications;
-    std::mutex mtx;
-    std::vector<std::thread*> countdownThreads;
-    int millisecondsDevicePolicyWait = 500;
+    std::map<uint32_t, DevicePresenceInfo> _deviceNotifications;
+    std::mutex _mtx;
+    std::vector<std::thread*> _countdownThreads;
+    const int _kMillisecondsDevicePolicyWait = 500;
 };
 
 } // namespace usbguardNotifier


### PR DESCRIPTION
Merge notifications when inserting devices.

When inserting a device with an `allow` usbguard rule, usbguard-notifier shows 2 notifications:
* `insert XXX :block`
* `XXX: allow`
This PR merges it to 1 notification displaying `insert XXX :ACTUAL_RULE`

#### Advantages

Less notifications: When you insert a device, it shows 2 notifications.
It can clutter the screen. 
Example: when I plug my USB hub with 2 devices on it, I get 6 notifications.

This PR will also help [another PR](https://github.com/Cropi/usbguard-notifier/pull/62) I am making.
It will allow to check the rule of an inserted device and show an an "allow" action button if the device is blocked. (For now it shows even when the device is already allowed)


#### implementation details

The IPC device messages when inserting an allowed device work in two times:
* It first sends an `PresenceChanged` with a `device_rule=block ...` 
* Then a `PolicyChanged` with `device_rule=allow ...`

See [this issue](https://github.com/USBGuard/usbguard/issues/401) I posted on USBGuard's github for more details and logs of this behavior.

In this PR, When receiving a `PresenceChanged` message we wait on its `PolicyChanged` message, to merge both informations.

For now, the `PolicyChanged` message is not always fired, so we can't reliably count on it. this [pull request](https://github.com/USBGuard/usbguard/pull/385) attemps to fix this problem.
That is why I do not wait indefinitely but with a small countdown for the `PolicyChanged` message.
(and that's why I use threads, pointers, objects with an `isInitialized` field…)

#### Screenshots

current behavior             |  new behavior
:-------------------------:|:-------------------------:
![screenshot_current behavior](https://user-images.githubusercontent.com/24274639/89720525-52e09c00-d9d3-11ea-9446-35ece800fc9f.png) | ![screenshot_new behavior](https://user-images.githubusercontent.com/24274639/89720528-570cb980-d9d3-11ea-8097-9a976ef6fa8a.png)

