### PR TITLE
[PoC] action button to allow a new device from a notification

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv)
     bool wait_connection = false, debug = false;
     int opt;
 
+    GMainLoop* loop = g_main_loop_new(nullptr, FALSE);
     while ((opt = getopt_long(argc, argv, short_options, long_options, nullptr)) != -1) {
         switch (opt) {
         case 'w':
@@ -76,7 +77,8 @@ int main(int argc, char** argv)
             usbguardNotifier::Notifier notifier(app_name);
             notifier.connect();
             std::cout << "Connection has been established" << std::endl;
-            notifier.wait();
+            g_main_loop_run(loop);
+            //notifier.wait();
         } catch (const std::runtime_error& e) {
             std::cerr << "Error:" << e.what() << std::endl;
             return EXIT_FAILURE;

--- a/src/Notifier.cpp
+++ b/src/Notifier.cpp
@@ -87,6 +87,16 @@ void Notifier::DevicePresenceChanged(
 
     notify::Notification n("USBGuard", body.str());
     n.setTimeout(5000);
+
+    // TODO: is "EventType::Insert only sufficent?
+    // or should it be !EventType::Remove ?"
+    // should it be only block and reject or everything but Allow?
+    // please give feedback as I am not much versed on usbguard rules.
+
+    if (event == usbguard::DeviceManager::EventType::Insert &&
+        (target == Rule::Target::Block || target == Rule::Target::Reject)) {
+        n.setAllowAction(rule, this);
+    }
     n.setCategory("device");
     if (!n.show()) {
         throw std::runtime_error("Failed to show notification");


### PR DESCRIPTION
##### Proposition of new feature
I created an action button that appears on the notification for a new blocked device.
Pressing it will create a new rule allowing the device.

![screenshot_usbguard_notifier_allow](https://user-images.githubusercontent.com/24274639/89720705-858b9400-d9d5-11ea-8fe6-5101b01ba2dd.png)


##### Use case (personal):                                                          
I would like to use USBGuard to protect myself from indiscreet people that could plug any device (like a RubberDucky) on my computer while I leave it unattended for a few seconds. But I would also like to use new USB devices easily, without manually creating a new rule every time.


##### problems encountered and need for advice

I wanted to have USBGuard-notifier to work on an unprivileged user level, and ask for authentication to create new rules.
Otherwise an attacker could just click on the notification, and it would be only a weak protection.

* I started using the internal IPC client of the program to add new rules.
But for it to work you need either to run USBGuard-notifier as root, or add rights for the user to change USBGuard policy.
In both case I didn't find a way to ask the user to identify himself again by asking his password before adding the rule.

* Then I used the `pkexec` tool to run a `usbguard append-rule` from the command line (using `system`).
An auth window pops up on the screen asking for admin rights, and executes the command.
It works, but the user needs to have pkexec installed, and it uses the `system()` method in C++. 
`exec` method do not work, as `pkexec` needs to be launched from a shell.
`system()` can be a dangerous method. I almost missed a command injection bug while writing the code. I may have only fixed it partially…

* We could also use [Polkit](https://wiki.archlinux.org/index.php/Polkit) to authenticate for the `appendrule` request.
But in this case, from what I understood of Polkit philosophy. we should either:
  * Send the request via D-Bus, and have the usbguard-dbus service running.
  * Modify the usbguard service to use polkit, instead of its IPC Access Control system. 
  (See [this issue](https://github.com/USBGuard/usbguard/issues/393) that also raises the fact that there a 2 different authentication mechanisms for USBGuard depending on the method of communication with the service)

* <details> <summary> ⚠️ Bad idea ⚠️ </summary>

  We can also give a fake sense of security by still allowing users to modify policies by IPC, but check for admin rights when clicking the notification.
  So the notification will have a pop up for an admin password, but you can still just do `usbguard append-rule ...` on a shell without having his password asked.

  I present this idea just because I spent some time doing something like this before understanding how Polkit works.
  </details>

#### Conclusion
 So : do you have any suggestion about this feature, and how to implement it?
* Do you find the feature of allowing devices from a notification useful?
* If yes, do you have any idea how to implement this securely?


#### Minor other issues
 * I implemented a check to add the action to the notification only for inserted and blocked devices. However the check does not work for now as the the IPC device messages when inserting an allowed device works in two times, and an inserted device event will always have a rule saying `device_rule=block ...`.
 
   See [this PR](https://github.com/Cropi/usbguard-notifier/pull/61) I made that attempts to fix this issue.

* The condition to check whereas to show the action or not may be improved.
  I don't know yet if it can miss cases, or include too many…

* To have the button callback called, the program must run a [Gtk Main Event Loop](https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html). As USBGuard-notifier already has a main loop waiting on the IPC connection, I removed this IPC wait from this PoC.
  
  For a final implementation, we should have a way to have the two loops running.
  I saw that it *may* be possible to inherit from the Gtk main loop and rewrite it  with custom logic, but I didn't find any details about it yet.

##### configuration to have to Poc working:                                         
* run usbguard service and give it permissions for the current user
* <details>
  <summary> [Arch Linux] fix issues with USBGuard that appear on this distribution </summary>
  
  * Create a file `/etc/systemd/system/usbguard.service.d/override.conf` and add the `[Service]` line to it
  * Fix an [issue](https://github.com/USBGuard/usbguard/issues/380) preventing to use IPC commands as on-root user 
  (even with [IPC interface access control](https://usbguard.github.io/blog/2017/IPC-Access-Control) set up)
    * add the line `CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE` to the `override.conf` file
  * Manually fix an [issue](https://github.com/USBGuard/usbguard/issues/347) corrected on upstream but not Arch's repositories release.<br>
    It prevents the IPC clients to write new permanent rules.
    * add the line `ReadWritePaths=-/dev/shm -/var/log/usbguard -/tmp -/etc/usbguard` to the `override.conf` file
</details>

* Configure the [IPC interface access control](https://usbguard.github.io/blog/2017/IPC-Access-Control) for USBGuard.<br>
  ```bash
  $ sudo usbguard add-user `whoami` --devices listen
  ```
    * to test the method which uses the internal IPC connection of USBGuard-notifer, add the `--policy modify` option to your `usbguard add-user`
    :warning: This configuration is **not nice** >:] as it allows the current user to add new USBGuard rules.

* `sudo systemctl start usbguard.service`
* on the project's folder: `make && ./usbguard-notifier`
