### PR TITLE
Decrease spam when IPC connection fails

### DIFF
--- a/man/usbguard-notifier.1.adoc
+++ b/man/usbguard-notifier.1.adoc
@@ -27,6 +27,33 @@ USBGuard Notifier is a software framework mainly for detecting usbguard policy m
     Show help.
 
 
+== HOW TO START
+In order to make usbguard-notifier work properly, you will need to perform certain actions:
+
+ 1. Each user who wants to run usbguard-notifier service needs to have sufficient IPC privileges to connect to the usbguard IPC interface.
+    To allow a specific user to listen to the device signals you can use the following command: +
+    +
+    *$ sudo usbguard add-user* 'USER' *-d listen* +
+    +
+    Or you can allow a group of users: +
+    +
+    *$ sudo usbguard add-user -g* 'GROUP' *-d listen*
+
+ 2. Now, you need a running usbguard-daemon instance to connect to.
+    Start the usbguard service or restart it if it is already running.
+
+ 3. After configuring IPC privileges and starting up the usbguard-daemon, the user can now start the usbguard-notifier service: +
+    +
+    *$ systemctl start --user usbguard-notifier.service* +
+    +
+    Optionally, the user can enable the usbguard-notifier service to start automatically after the login: +
+    +
+    *$ systemctl enable --user usbguard-notifier.service*
+
+The usbguard-notifier should now be running.
+Anytime a USB device gets inserted/ejected or allowed/blocked a message will pop up in the user's graphical interface.
+
+
 == SEE ALSO
 link:usbguard-notifier-cli.1.adoc#name[usbguard-notifier-cli(1)],
 link:usbguard.1.adoc#name[usbguard(1)]

--- a/usbguard-notifier.service.in
+++ b/usbguard-notifier.service.in
@@ -3,7 +3,7 @@ Description=USBGuard Notifier
 After=usbguard.service
 
 [Service]
-ExecStart=%bindir%/usbguard-notifier -w
+ExecStart=%bindir%/usbguard-notifier
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
* adds --num-attempts option
* usbguard-notifier will try to connect 3 times instead of infinite wait
* usbguard-notifier does not spam messages on consecutive connection fails
* add a HOW TO START section into manual page