### PR TITLE
Action buttons to allow or reject devices from notification

### DIFF
--- a/src/Notifier.cpp
+++ b/src/Notifier.cpp
@@ -177,14 +177,14 @@ void Notifier::sendDevicePresenceNotification(DevicePresenceInfo& info)
     // TODO serialize
 }
 
-void Notifier::actionsCallback(std::string action_id, DevicePresenceInfo* info)
+void Notifier::actionsCallback(const std::string& action_id, DevicePresenceInfo* info)
 {
     using namespace usbguard;
 
     try {
-        if (action_id == "allow") {
+        if (Rule::targetFromString(action_id)  == Rule::Target::Allow) {
             IPCClient::applyDevicePolicy(info->id, usbguard::Rule::Target::Allow, false);
-        } else if (action_id == "reject") {
+        } else if (Rule::targetFromString(action_id)  == Rule::Target::Reject) {
             IPCClient::applyDevicePolicy(info->id, usbguard::Rule::Target::Reject, false);
         }
         NOTIFIER_LOG() << "Device Policy '" << action_id

--- a/src/Notifier.cpp
+++ b/src/Notifier.cpp
@@ -58,6 +58,7 @@ Notifier::~Notifier()
     }
 
     g_main_loop_quit(_GMLoop);
+    _GMLoopThread->join();
     delete _GMLoopThread;
 }
 

--- a/src/Notifier.cpp
+++ b/src/Notifier.cpp
@@ -163,11 +163,11 @@ void Notifier::sendDevicePresenceNotification(DevicePresenceInfo& info)
     if (info.event == DeviceManager::EventType::Insert) {
         _actionsCallbackUserData.info = &info;
         if (info.target != Rule::Target::Allow) {
-            n.addAction("allow", "Allow",
+            n.addAction(Rule::targetToString(Rule::Target::Allow), "Allow",
                 &Notifier::actionsCallbackWrapper,
                 &_actionsCallbackUserData);
         }
-        n.addAction("reject", "Reject",
+        n.addAction(Rule::targetToString(Rule::Target::Reject), "Reject",
             &Notifier::actionsCallbackWrapper,
             &_actionsCallbackUserData);
     }

--- a/src/Notifier.hpp
+++ b/src/Notifier.hpp
@@ -110,7 +110,7 @@ private:
 
     void sendDevicePresenceNotification(DevicePresenceInfo& info);
 
-    void actionsCallback(std::string action_id, DevicePresenceInfo* info);
+    void actionsCallback(const std::string& action_id, DevicePresenceInfo* info);
 
     notify::Notify _lib;
     Serializer _ser;

--- a/src/Notifier.hpp
+++ b/src/Notifier.hpp
@@ -56,18 +56,52 @@ public:
             const std::string& value_old,
             const std::string& value_new);
     */
+
+    /**
+     * @brief Notification action's C-style callback
+     * This callback later calls private method 'actionsCallback' which is the "desired"
+     * callback as it can access class members.
+     *
+     * @see \link notify::Notification::addAction addAction\endlink
+     *
+     * @param n Not in use. Imposed by libnotify API.
+     * @param action Action ID.
+     * @param user_data Pointer to _actionsCallbackUserData in an object instance.
+     */
+    static void actionsCallbackWrapper(
+        NotifyNotification* n,
+        char* action,
+        gpointer user_data);
+
 private:
     struct DevicePresenceInfo {
         bool isInitialized = false;
+        uint32_t id;
         usbguard::DeviceManager::EventType event;
         usbguard::Rule::Target target;
         std::string device_rule;
 
-        DevicePresenceInfo(const usbguard::DeviceManager::EventType& e,
+        DevicePresenceInfo(const uint32_t id,
+            const usbguard::DeviceManager::EventType& e,
             const usbguard::Rule::Target& t,
-            const std::string& r): isInitialized(true), event(e), target(t), device_rule(r) {}
+            const std::string& r): isInitialized(true), id(id), event(e), target(t), device_rule(r) {}
 
-        DevicePresenceInfo() : event(), target(), device_rule() {}
+        DevicePresenceInfo() : id(0), event(), target(), device_rule() {}
+    };
+
+    /**
+     * @brief Structure passed as argument in notification action's callback.
+     *
+     * @see \link Notification::addAction addAction\endlink
+     * @see \link Notifier::actionsCallback actionsCallback\endlink
+     */
+    struct ActionsCallbackUserData {
+        Notifier* object_ptr; /**< Reference to class instance. */
+        DevicePresenceInfo* info; /**< Device information needed by \link actionsCallback actionsCallback\endlink method. */
+
+        ActionsCallbackUserData(Notifier* ctx, DevicePresenceInfo* info) : object_ptr(ctx), info(info) {};
+
+        ActionsCallbackUserData() : object_ptr(nullptr), info(nullptr) {};
     };
 
     DevicePresenceInfo getDevicePresenceObject(uint32_t id);
@@ -76,12 +110,19 @@ private:
 
     void sendDevicePresenceNotification(DevicePresenceInfo& info);
 
+    void actionsCallback(std::string action_id, DevicePresenceInfo* info);
+
     notify::Notify _lib;
     Serializer _ser;
     std::map<uint32_t, DevicePresenceInfo> _deviceNotifications;
     std::mutex _mtx;
     std::vector<std::thread*> _countdownThreads;
     const int _kMillisecondsDevicePolicyWait = 500;
+
+    GMainLoop* _GMLoop;
+    std::thread* _GMLoopThread;
+
+    ActionsCallbackUserData _actionsCallbackUserData;
 };
 
 } // namespace usbguardNotifier

--- a/src/NotifyWrapper.cpp
+++ b/src/NotifyWrapper.cpp
@@ -92,4 +92,14 @@ bool Notification::close() const
     return notify_notification_close(_n, nullptr);
 }
 
+void Notification::addAction(
+    const std::string& action,
+    const std::string& label,
+    void (*callback)(NotifyNotification*, char*, gpointer),
+    gpointer user_data) noexcept
+{
+    notify_notification_add_action(_n, action.c_str(), label.c_str(),
+        (NotifyActionCallback)callback, user_data, NULL);
+}
+
 } // namespace notify

--- a/src/NotifyWrapper.hpp
+++ b/src/NotifyWrapper.hpp
@@ -117,6 +117,24 @@ public:
     void setUrgency(Urgency urgency) noexcept;
 
     /**
+     * @brief Adds an action to the notification.
+     *
+     * libnotify uses a C-style callback so this type is needed as an argument.
+     * A static function is needed for this callback to work.
+     *
+     * @param action The action ID.
+     * @param label Human-readable action label. Shown in the notification.
+     * @param callback C-style callback as defined by libnotify.
+     * Callback parameter 'n' should not be used; 'action' and 'user_data' are the same.
+     * @param user_data Optional custom data to pass to callback.
+     */
+    void addAction(
+        const std::string& action,
+        const std::string& label,
+        void (*callback)(NotifyNotification* n, char* action, gpointer user_data),
+        gpointer user_data) noexcept;
+
+    /**
      * @brief Synchronously tells the notification server
      * to hide the notification on the screen.
      *


### PR DESCRIPTION
## Proposition of new feature

During the last few weeks I've been working in the implementation of a pair of action buttons in the notifications, "Allow" and "Reject".

While I was preparing this pull request I noticed @LucasParsy pull request implementing the same feature (#62). As my implementation is quite different from his and the PR has been open and inactive for almost two years, I decided to open a new request.

It should also be noted that this request changes the notification's title and body a bit to be more human-readable.

Here are a few screenshots showing the changes:

- When a permanently allowed device is:
  - Plugged: 
  ![2022-09-02_06-36-55](https://user-images.githubusercontent.com/56703081/188142677-affb160d-d521-43ed-a511-caf4b949a75b.png)
  - Unplugged:
  ![2022-09-02_06-37-11](https://user-images.githubusercontent.com/56703081/188142683-878ed75c-f8e6-4cc7-8045-a7f653a4b541.png)  
  - Rejected (by clicking "Reject"):
  ![2022-09-02_06-37-27](https://user-images.githubusercontent.com/56703081/188142686-383ddebc-6d7e-47d9-8739-d9c46121ecfb.png)
   "Update" notification is shown first.

- When a new device is:
  - Plugged:
  ![2022-09-02_06-37-48](https://user-images.githubusercontent.com/56703081/188142687-7a8370d2-c8b9-41ee-8b03-69ebbdaff07e.png)
  - Allowed (by clicking "Allow"):
  ![2022-09-02_06-38-04](https://user-images.githubusercontent.com/56703081/188142688-784ac28b-f43e-463b-8f81-476a4ee76225.png)
  - Unplugged and rejected: Same as with permanently allowed devices.

## How is it implemented

First, GLib Main Event Loop is kept inside its own thread as it's both needed for the buttons' callback to work, and blocks the execution of the program.
Compared with replacing `notifier.wait()` in Main (as suggested in #62), this seems to be a better way to do it because Notifier already creates and destroys threads in order to handle the notification. This means that we are sort of "extending" the idea of using threads in the `Notifier` class.

Second, the device policies are applied using the existing IPCClient interface as suggested in #62 and a wrapper to keep code consistent with `notify`.
The not-so-pretty part of doing this is the static method used to (1) handle the C-style callback imposed by libnotify, and (2) access an instance member function (non-static) to use IPCClient. I tried avoiding this while keeping the IPCClient idea without success.
It should be noted that this part of the source code was heavily inspired by `usbguard-applet-qt` implementation. See [`MainWindow::allowDevice` in the project source code](https://gitlab.com/WheelchairArtist/usbguard-applet-qt/-/blob/0d6ca25261a08f5945068d43ee502bfd7dadca46/src/MainWindow.cpp#L445).

Last, I decided not to implement a "permanent" option for allowing or rejecting an USB device. 
In my opinion it should be implemented in a window (like `usbguard-applet-qt`) or kept as a "manual task" to perform by editing `rules.conf`. Implementing this will either (a) show an extra notification, which seems pretty annoying, or (b) add another pair of buttons, making all of them pretty small and a source of human error (the notification will show four buttons when connecting a new device: "Allow", "Allow permanently", "Reject" and "Reject permanently").

---

This is my first-ever pull request so I'll be more than happy to fix any issues and discuss about this PR.

Thank you for your time,
Martín E. Zahnd