### PR TITLE
Fix compile with GCC 13

### DIFF
--- a/src/Serializer.hpp
+++ b/src/Serializer.hpp
@@ -20,6 +20,7 @@
 #ifndef SERIALIZER_HPP
 #define SERIALIZER_HPP
 
+#include <cstdint>
 #include <fstream>
 #include <map>
 #include <string>


### PR DESCRIPTION
This is needed for https://gcc.gnu.org/gcc-13/porting_to.html
