### PR TITLE
tests: add support for Catch2 v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,13 +138,17 @@ if test "x$with_bundled_catch" = xyes; then
     catch_summary="bundled; $catch_CFLAGS $catch_LIBS"
 else
     SAVE_CPPFLAGS=$CPPFLAGS
-    CPPFLAGS="-std=c++11 $CPPFLAGS -I/usr/include/catch"
+    CPPFLAGS="-std=c++17 $CPPFLAGS -I/usr/include/catch2"
     AC_LANG_PUSH([C++])
-    AC_CHECK_HEADER([catch.hpp], [], [AC_MSG_FAILURE(catch.hpp not found or not
-        usable. Re-run with --with-bundled-catch to use the bundled library.)])
+	AC_CHECK_HEADER([catch_test_macros.hpp],
+	[catch_CFLAGS="-I/usr/include/catch2 -DHAVE_CATCH2_V3"
+	catch_LIBS="-lCatch2Main -lCatch2"],
+        [AC_CHECK_HEADER([catch.hpp],
+	[catch_CFLAGS="-I/usr/include/catch2"
+	catch_LIBS=""],
+        [AC_MSG_FAILURE(Catch2 not found or not usable. Re-run with --with-bundled-catch to use the bundled library.)]
+        )])
     AC_LANG_POP
-    catch_CFLAGS="-I/usr/include/catch"
-    catch_LIBS=""
     CPPFLAGS=$SAVE_CPPFLAGS
     catch_summary="system-wide;
     $catch_CFLAGS $catch_LIBS"
@@ -165,7 +169,7 @@ AC_ARG_ENABLE(
 )
 
 CXXFLAGS=" $EXTERNAL_CXXFLAGS"
-CXXFLAGS+=" -std=c++11"
+CXXFLAGS+=" -std=c++17"
 CXXFLAGS+=" -pedantic"
 CXXFLAGS+=" -Wno-unknown-pragmas"
 CXXFLAGS+=" -Wall"

--- a/src/Tests/Makefile.am
+++ b/src/Tests/Makefile.am
@@ -43,3 +43,6 @@ test_unit_SOURCES=\
     ../NotifierCLI.cpp \
     ../Serializer.hpp \
     ../Serializer.cpp
+
+test_unit_LDADD = \
+    $(catch_LIBS)

--- a/src/Tests/Unit/test_notifier_cli.cpp
+++ b/src/Tests/Unit/test_notifier_cli.cpp
@@ -1,6 +1,10 @@
 #include "NotifierCLI.hpp"
 
+#ifdef HAVE_CATCH2_V3
+#include <catch_test_macros.hpp>
+#else
 #include <catch.hpp>
+#endif
 
 using namespace usbguardNotifier;
 

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -1,2 +1,6 @@
+#ifdef HAVE_CATCH2_V3
+#include <catch_test_macros.hpp>
+#else
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
+#endif


### PR DESCRIPTION
Catch2 v3 no longer has a monolithic <catch.hpp> and also requires linking against compiled libraries:

https://github.com/catchorg/Catch2/blob/v3.0.1/docs/migrate-v2-to-v3.md

This allows either v2 or v3 of system-installed Catch2 to be used.

Related: https://github.com/USBGuard/usbguard/pull/659
