### PR TITLE
autotools: concatenate $CXXFLAGS in a posix compliant manner

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,11 +140,11 @@ AC_ARG_ENABLE(
 )
 
 CXXFLAGS=" $EXTERNAL_CXXFLAGS"
-CXXFLAGS+=" -std=c++11"
-CXXFLAGS+=" -pedantic"
-CXXFLAGS+=" -Wno-unknown-pragmas"
-CXXFLAGS+=" -Wall"
-CXXFLAGS+=" -Wextra"
+CXXFLAGS="$CXXFLAGS -std=c++11"
+CXXFLAGS="$CXXFLAGS -pedantic"
+CXXFLAGS="$CXXFLAGS -Wno-unknown-pragmas"
+CXXFLAGS="$CXXFLAGS -Wall"
+CXXFLAGS="$CXXFLAGS -Wextra"
 
 if test "x$debug" = xyes; then
     CXXFLAGS="$CXXFLAGS $CXXFLAGS_DEBUG"


### PR DESCRIPTION
The += operator is not posix compliant and on systems where /bin/sh points to a posix compliant shell, CXXFLAGS+= will be treated as a command to execute:

./configure: 19608: CXXFLAGS+= -std=c++11: not found
./configure: 19609: CXXFLAGS+= -pedantic: not found
./configure: 19610: CXXFLAGS+= -Wno-unknown-pragmas: not found
./configure: 19611: CXXFLAGS+= -Wall: not found
./configure: 19612: CXXFLAGS+= -Wextra: not found