### PR TITLE
Run USBGuard notifier only for graphical sessions

### DIFF
--- a/usbguard-notifier.service.in
+++ b/usbguard-notifier.service.in
@@ -1,9 +1,10 @@
 [Unit]
 Description=USBGuard Notifier
 After=usbguard.service
+PartOf=graphical-session.target
 
 [Service]
 ExecStart=%bindir%/usbguard-notifier
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
To avoid the crash reported in #81, run USBGuard notifier only within the context of a graphical session.